### PR TITLE
Fix libfrida installation on Android from APK and improvement #2

### DIFF
--- a/getfridalibs.sh
+++ b/getfridalibs.sh
@@ -4,26 +4,20 @@ echo -n "Geting Frida libs from the repo... "
 wget -qO - https://github.com/frida/frida/releases/latest | grep -o "\/frida\/frida\/releases\/download\/.*\/frida-gadget-.*-android-.*\.so\.xz" | sed 's/\/frida\/frida/https:\/\/github\.com\/frida\/frida/g' | sed 's/%0A/\n/g' > list.txt
 wget -q -i list.txt
 echo "DONE"
+
+echo -n "Unpacking libs and cleaning temp files... "
 unxz *.xz
 
-
-mkdir frida_libs
-mkdir frida_libs/arm64 frida_libs/arm64-v8a frida_libs/armeabi frida_libs/armeabi-v7a frida_libs/x86 frida_libs/x86_64
+mkdir -p frida_libs/arm64 frida_libs/arm64-v8a frida_libs/armeabi frida_libs/armeabi-v7a frida_libs/x86 frida_libs/x86_64
 mv *.so frida_libs/
 cd frida_libs/
 
-cp *-arm64.so arm64
-mv arm64/*.so arm64/libfrida-gadget.so
-cp *-arm64.so arm64-v8a
-mv arm64-v8a/*.so arm64-v8a/libfrida-gadget.so
-cp *-arm.so armeabi
-mv armeabi/*.so armeabi/libfrida-gadget.so
-cp *-arm.so armeabi-v7a
-mv armeabi-v7a/*.so armeabi-v7a/libfrida-gadget.so
-cp *-i386.so x86
-mv x86/*.so x86/libfrida-gadget.so
-cp *-x86_64.so x86_64
-mv x86_64/*.so x86_64/libfrida-gadget.so
+cp -f *-android-arm64.so arm64/libfrida-gadget.so
+cp -f *-android-arm64.so arm64-v8a/libfrida-gadget.so
+cp -f *-android-arm.so armeabi/libfrida-gadget.so
+cp -f *-android-arm.so armeabi-v7a/libfrida-gadget.so
+cp -f *-android-x86.so x86/libfrida-gadget.so
+cp -f *-android-x86_64.so x86_64/libfrida-gadget.so
 rm -rf *.so
 cd ..
 
@@ -31,3 +25,4 @@ cd ..
 find . -name ".DS_*" -type f -delete
 find . -name "*~*" -type f -delete
 rm -rf list.txt
+echo "Done"

--- a/getfridalibs.sh
+++ b/getfridalibs.sh
@@ -3,7 +3,7 @@
 echo -n "Geting Frida libs from the repo... "
 wget -qO - https://github.com/frida/frida/releases/latest | grep -o "\/frida\/frida\/releases\/download\/.*\/frida-gadget-.*-android-.*\.so\.xz" | sed 's/\/frida\/frida/https:\/\/github\.com\/frida\/frida/g' | sed 's/%0A/\n/g' > list.txt
 wget -q -i list.txt
-echo "DONE"
+echo "Done"
 
 echo -n "Unpacking libs and cleaning temp files... "
 unxz *.xz
@@ -21,8 +21,7 @@ cp -f *-android-x86_64.so x86_64/libfrida-gadget.so
 rm -rf *.so
 cd ..
 
-
-find . -name ".DS_*" -type f -delete
-find . -name "*~*" -type f -delete
+find . -name ".DS_*" -type f -delete 2>/dev/null
+find . -name "*~*" -type f -delete 2>/dev/null
 rm -rf list.txt
 echo "Done"

--- a/lazyDroid.sh
+++ b/lazyDroid.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-# lazzyDroid
+#!/usr/bin/env bash
+# lazyDroid
 # 2017 By Dani Martinez (@dan1t0) / NCCGroup
 
 VERSION="0.4"
@@ -216,7 +216,7 @@ function set_something {
 function smartLog {
     echo -n "Execute the app and enter the name: "
     read packageName
-    ${ADB} shell "ps | grep $packageName" > /tmp/pids
+    ${ADB} shell ps | grep $packageName > /tmp/pids
     PIDS="$(wc -l /tmp/pids | cut -d" " -f1)"
     DATE=$(date +"%Y%m%d%H%M%S")
     FOLDER=$PWD

--- a/lazyDroid.sh
+++ b/lazyDroid.sh
@@ -253,7 +253,7 @@ function smartLog {
                     echo  "Log stored on '${FOLDER}/${packageName}_${DATE}.log'"
                     echo -n "Press Enter to continue... "
                     read kk
-                    ${MYSHELL} -e "${ADB} logcat | grep ${PIDD_} | tee -a "${FOLDER}/${packageName}_${DATE}.log"" &
+                    ${MYSHELL} -e "${ADB} logcat | grep ${PIDD_} | tee -a ${FOLDER}/${packageName}_${DATE}.log" &
                 fi
             else
                 PIDD_="$(cat /tmp/pids | awk '{print $2}')"
@@ -262,7 +262,7 @@ function smartLog {
                 echo "Log stored on '${FOLDER}/${packageName}_${DATE}.log'"
                 echo -n "Press Enter to continue... "
                 read kk
-                ${MYSHELL} -e "${ADB} logcat | grep ${PIDD_} | tee -a "${FOLDER}/${packageName}_${DATE}.log"" &
+                ${MYSHELL} -e "${ADB} logcat | grep ${PIDD_} | tee -a ${FOLDER}/${packageName}_${DATE}.log" &
             fi
 
         fi

--- a/lazyDroid.sh
+++ b/lazyDroid.sh
@@ -688,7 +688,8 @@ EOF
         mv ${file_to_patch}.1 ${file_to_patch}
 
         echo -n "---> Injecting the shared libraries..."
-        cp -r frida_libs/${arch} ${APK_DIR}/lib/
+        mkdir -p ${APK_DIR}/lib/
+	cp -r frida_libs/${arch}/ ${APK_DIR}/lib/
         echo " DONE"
         echo ""
 

--- a/lazyDroid.sh
+++ b/lazyDroid.sh
@@ -15,7 +15,7 @@ AAPT="aapt"
 KEYSTORE="keystore.key"
 KEYALIAS="danito"
 
-MYSHELL="gnome-terminal"
+MYSHELL="x-terminal-emulator"
 #######################
 
 


### PR DESCRIPTION
Hi,
This PR provides improvement related to the issue #2.

In my cases, the libfrida file wasn't copy in the app's lib folder (`/data/data/<app>/lib/`).
In the APK file, the libfrida file was in `lib/` instead of `lib/<arch>/`.
The second commit fixes this issue.